### PR TITLE
Fixe le problème des titres de feuilles Excel pouvant contenir des ca…

### DIFF
--- a/3rparty/PHPExcel/Classes/PHPExcel/Worksheet.php
+++ b/3rparty/PHPExcel/Classes/PHPExcel/Worksheet.php
@@ -448,7 +448,10 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
     {
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ]
         if (str_replace(self::$invalidCharacters, '', $pValue) !== $pValue) {
-            throw new PHPExcel_Exception('Invalid character found in sheet title');
+            //throw new Exception('Invalid character found in sheet title');
+
+            //Hack to remove bad characters from sheet name instead of throwing an exception
+            return str_replace(self::$_invalidCharacters, '', $pValue);
         }
 
         // Maximum 31 characters allowed for sheet title


### PR DESCRIPTION
…ractères invalides

Le titre étant d'aucune utilité et la bibliothèque ne gérant pas ce type de cas, il est nécessaire de la modifier.
https://stackoverflow.com/a/21835178